### PR TITLE
Support pow (**) operator in Fluid VTL

### DIFF
--- a/fluid/parse_ast.py
+++ b/fluid/parse_ast.py
@@ -216,7 +216,8 @@ class BinOpType(enum.Enum):
     EQ = 8,
     NOT_EQ = 9,
     DIV = 10,
-    SL = 11
+    SL = 11,
+    POW = 12
 
     def __str__(self):
         if self == BinOpType.AND:
@@ -241,6 +242,8 @@ class BinOpType(enum.Enum):
             return "div"
         elif self == BinOpType.SL:
             return "sl"
+        elif self == BinOpType.POW:
+            return "pow"
 
     def to_string(self):
         if self == BinOpType.AND:
@@ -267,6 +270,8 @@ class BinOpType(enum.Enum):
             return "/"
         elif self == BinOpType.SL:
             return "<<"
+        elif self == BinOpType.POW:
+            return "**"
 
     @staticmethod
     def from_string(string):
@@ -294,6 +299,8 @@ class BinOpType(enum.Enum):
             return BinOpType.DIV
         elif string == "<<":
             return BinOpType.SL
+        elif string == "**":
+            return BinOpType.POW
         else:
             print(string, "unrecognized op type")
         

--- a/fluid/vtl.py
+++ b/fluid/vtl.py
@@ -153,6 +153,8 @@ class VTLCompiler(ast.NodeVisitor):
                 op_str = "/"
             elif isinstance(expr.op, ast.LShift):
                 op_str = "<<"
+            elif isinstance(expr.op, ast.Pow):
+                op_str = "**"
             return mk_binary(op_str, self.compile_expr(expr.left), self.compile_expr(expr.right))
         elif isinstance(expr, ast.UnaryOp):
             op_str = "~"


### PR DESCRIPTION
Adding support for the power (**) operator to Fluid. Currently, using ** in the RHS of a VTL expression doesn't translate to the right operand in the resulting SystemVerilog code. For instance, compiling `HEAP_NUM_PRIORITIES = Param(HEAP_BITMAP_WIDTH ** 2)` yields `parameter HEAP_NUM_PRIORITIES = (HEAP_BITMAP_WIDTH + 2);`. After this change: `parameter HEAP_NUM_PRIORITIES = (HEAP_BITMAP_WIDTH ** 2);`.

Testing:
- Ran `./run_pigasus.sh` without any changes to pigasus.py; as expected, struct_s.sv remains unchanged
- Re-ran `./run_pigasus.sh` after adding a dummy parameter that uses **, which produces the expected result

PS: Looks like the compiler doesn't currently complain about unrecognized binary operands, but simply defaults to `+`. This might make it hard to distinguish actual RTL bugs from unimplemented compiler functionality (leading to, e.g., incorrect params). Perhaps we should just error out with a "File a bug" message instead?