### PR TITLE
Support non-constexpr widths for extern signals in VTL

### DIFF
--- a/fluid/genericplatform.py
+++ b/fluid/genericplatform.py
@@ -56,7 +56,8 @@ class GenericTopPass(Pass):
 
         #generate externs
         for extern in app.externs.values():
-            ports.port(extern.name, mk_type("logic", extern.size-1, 0), extern.direction)
+            upper = "{}-1".format(extern.size) if isinstance(extern.size, str) else (extern.size - 1)
+            ports.port(extern.name, mk_type("logic", upper, 0), extern.direction)
     
         for extifc in app.extern_interfaces.values():
             ports.port(extifc.name, Type(mk_attrib(extifc.type)))


### PR DESCRIPTION
Currently, any extern signals generated by VTL must have widths that are known at VTL compile-time. This prevents us from using "late-binding" constants (i.e., values that are known only when the RTL design itself is compiled) or `include-d parameters (e.g., from struct_s.sv) in the signal list. This change fixes that by treating Python strings passed as Extern::size arguments differently from other types; when this occurs, the compiler simply emits "SIZE-1", allowing arbitrary specification of signal width.

Testing:
- Ran run_pigasus.sh and run_pigasus_multi.sh as-is, producing no change to auto-generated files
- Re-ran the scripts after changing an extern signal's width to a string, producing the expected result